### PR TITLE
Mammoth bug hunt solved by fixing for loop indexing error in Conducta…

### DIFF
--- a/Models/FourLayerVisionSpikingModel.cu
+++ b/Models/FourLayerVisionSpikingModel.cu
@@ -4,6 +4,11 @@
 // FourLayerVisionSpikingModel Constructor
 FourLayerVisionSpikingModel::FourLayerVisionSpikingModel () { 
 
+	lif_spiking_neurons = NULL;
+	image_poisson_input_spiking_neurons = NULL;
+	conductance_spiking_synapses = NULL;
+	evans_stdp = NULL;
+
 	// Network size parameters
 	number_of_non_input_layers = 4;
 	number_of_non_input_layers_to_simulate = number_of_non_input_layers;

--- a/Models/SpikingModel.cu
+++ b/Models/SpikingModel.cu
@@ -138,21 +138,43 @@ void SpikingModel::reset_model_activities() {
 
 void SpikingModel::perform_per_timestep_model_instructions(float current_time_in_seconds, bool apply_stdp_to_relevant_synapses){
 
-	spiking_neurons->reset_current_injections();
+	spiking_neurons->update_membrane_potentials(timestep, current_time_in_seconds);
+	input_spiking_neurons->update_membrane_potentials(timestep, current_time_in_seconds);
 
 	spiking_neurons->check_for_neuron_spikes(current_time_in_seconds, timestep);
 	input_spiking_neurons->check_for_neuron_spikes(current_time_in_seconds, timestep);
 
 	spiking_synapses->interact_spikes_with_synapses(spiking_neurons, input_spiking_neurons, current_time_in_seconds, timestep);
 
+	spiking_neurons->reset_current_injections();
 	spiking_synapses->calculate_postsynaptic_current_injection(spiking_neurons, current_time_in_seconds, timestep);
 
 	if (apply_stdp_to_relevant_synapses){
 		stdp_rule->Run_STDP(spiking_neurons->d_last_spike_time_of_each_neuron, current_time_in_seconds, timestep);
 	}
 
-	spiking_neurons->update_membrane_potentials(timestep, current_time_in_seconds);
-	input_spiking_neurons->update_membrane_potentials(timestep, current_time_in_seconds);
-
 }
+
+
+// PREVIOUS PER TIMESTEP MODEL INSTRUCTIONS. KEEP FOR NOW FOR COMPARISON, ALTHOUGH NEW ORDERING SHOULD WORK + MORE LOGICAL
+
+// void SpikingModel::perform_per_timestep_model_instructions(float current_time_in_seconds, bool apply_stdp_to_relevant_synapses){
+
+// 	spiking_neurons->reset_current_injections();
+
+// 	spiking_neurons->check_for_neuron_spikes(current_time_in_seconds, timestep);
+// 	input_spiking_neurons->check_for_neuron_spikes(current_time_in_seconds, timestep);
+
+// 	spiking_synapses->interact_spikes_with_synapses(spiking_neurons, input_spiking_neurons, current_time_in_seconds, timestep);
+
+// 	spiking_synapses->calculate_postsynaptic_current_injection(spiking_neurons, current_time_in_seconds, timestep);
+
+// 	if (apply_stdp_to_relevant_synapses){
+// 		stdp_rule->Run_STDP(spiking_neurons->d_last_spike_time_of_each_neuron, current_time_in_seconds, timestep);
+// 	}
+
+// 	spiking_neurons->update_membrane_potentials(timestep, current_time_in_seconds);
+// 	input_spiking_neurons->update_membrane_potentials(timestep, current_time_in_seconds);
+
+// }
 

--- a/Synapses/ConductanceSpikingSynapses.cu
+++ b/Synapses/ConductanceSpikingSynapses.cu
@@ -52,7 +52,7 @@ void ConductanceSpikingSynapses::AddGroup(int presynaptic_group_id,
 
 	conductance_spiking_synapse_parameters_struct * conductance_spiking_synapse_group_params = (conductance_spiking_synapse_parameters_struct*)synapse_params;
 
-	for (int i = (total_number_of_synapses - temp_number_of_synapses_in_last_group); i < total_number_of_synapses-1; i++){
+	for (int i = (total_number_of_synapses - temp_number_of_synapses_in_last_group); i < total_number_of_synapses; i++) {
 		synaptic_conductances_g[i] = 0.0f;
 		biological_conductance_scaling_constants_lambda[i] = conductance_spiking_synapse_group_params->biological_conductance_scaling_constant_lambda;
 		reversal_potentials_Vhat[i] = conductance_spiking_synapse_group_params->reversal_potential_Vhat;
@@ -140,6 +140,9 @@ void ConductanceSpikingSynapses::set_threads_per_block_and_blocks_per_grid(int t
 
 void ConductanceSpikingSynapses::calculate_postsynaptic_current_injection(SpikingNeurons * neurons, float current_time_in_seconds, float timestep) {
 
+	// First update the conductances
+	update_synaptic_conductances(timestep, current_time_in_seconds);
+
 	conductance_calculate_postsynaptic_current_injection_kernel<<<number_of_synapse_blocks_per_grid, threads_per_block>>>(d_presynaptic_neuron_indices,
 																	d_postsynaptic_neuron_indices,
 																	d_reversal_potentials_Vhat,
@@ -150,8 +153,6 @@ void ConductanceSpikingSynapses::calculate_postsynaptic_current_injection(Spikin
 
 	CudaCheckError();
 
-	// After injecting current, update the conductances
-	update_synaptic_conductances(timestep, current_time_in_seconds);
 }
 
 void ConductanceSpikingSynapses::update_synaptic_conductances(float timestep, float current_time_in_seconds) {


### PR DESCRIPTION
Mammoth bug hunt solved by fixing for loop indexing error in ConductanceSpikingSynapses::AddGroup. Was causing marginally different spike counts as last neuron was buggered by indexing problem. Several additional minor changes that were made whilst hunting, including more logical ordering of SpikingModel per_timestep_instructions